### PR TITLE
update omniauth-oauth2 dependency

### DIFF
--- a/omniauth-wordpress.gemspec
+++ b/omniauth-wordpress.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.1.0'
+  s.add_runtime_dependency 'omniauth-oauth2', '>= 1.1.0'
 
   s.add_development_dependency 'rspec', '~> 2.7.0'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
This fixes omniauth-oauth2 dependency conflict between omniauth-facebook and omniauth-wordpress.
