### PR TITLE
Use new 1.2.x version of omniauth-oauth2 to be compatible with other oau...

### DIFF
--- a/omniauth-wordpress.gemspec
+++ b/omniauth-wordpress.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.1.0'
+  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.2.0'
 
   s.add_development_dependency 'rspec', '~> 2.7.0'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Since we usually use this gem with other kind of oauth2 providers together,  we have to use the same version of omniauth-oauth2 gem.